### PR TITLE
Fix bugs and improve perf in Python apriltag bindings

### DIFF
--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -327,6 +327,7 @@ class Detector(object):
         assert len(img.shape) == 2
         assert img.dtype == numpy.uint8
 
+        img = numpy.ascontiguousarray(img)
         c_img = _ImageU8(height=img.shape[0], width=img.shape[1], stride=img.strides[0], buf=img.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8)))
 
         return_info = []

--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -283,40 +283,23 @@ class Detector(object):
 
         # create the family
         self.tag_families = dict()
-        if 'tag16h5' in self.params['families']:
-            self.tag_families['tag16h5'] = self.libc.tag16h5_create()
+        known_families = {
+            'tag16h5': (self.libc.tag16h5_create, self.libc.tag16h5_destroy),
+            'tag25h9': (self.libc.tag25h9_create, self.libc.tag25h9_destroy),
+            'tag36h11': (self.libc.tag36h11_create, self.libc.tag36h11_destroy),
+            'tagCircle21h7': (self.libc.tagCircle21h7_create, self.libc.tagCircle21h7_destroy),
+            'tagCircle49h12': (self.libc.tagCircle49h12_create, self.libc.tagCircle49h12_destroy),
+            'tagCustom48h12': (self.libc.tagCustom48h12_create, self.libc.tagCustom48h12_destroy),
+            'tagStandard41h12': (self.libc.tagStandard41h12_create, self.libc.tagStandard41h12_destroy),
+            'tagStandard52h13': (self.libc.tagStandard52h13_create, self.libc.tagStandard52h13_destroy),
+        }
+        for family in self.params['families']:
+            if family not in known_families:
+                raise Exception('Unrecognized tag family name: %r. Use e.g. \'tag36h11\'.\n' % family)
+            create_fn, destroy_fn = known_families[family]
+            self.tag_families[family] = (create_fn(), destroy_fn)
             self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
-                                                        self.tag_families['tag16h5'], hamming)
-        elif 'tag25h9' in self.params['families']:
-            self.tag_families['tag25h9'] = self.libc.tag25h9_create()
-            self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
-                                                        self.tag_families['tag25h9'], hamming)
-        elif 'tag36h11' in self.params['families']:
-            self.tag_families['tag36h11'] = self.libc.tag36h11_create()
-            self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
-                                                        self.tag_families['tag36h11'], hamming)
-        elif 'tagCircle21h7' in self.params['families']:
-            self.tag_families['tagCircle21h7'] = self.libc.tagCircle21h7_create()
-            self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
-                                                        self.tag_families['tagCircle21h7'], hamming)
-        elif 'tagCircle49h12' in self.params['families']:
-            self.tag_families['tagCircle49h12'] = self.libc.tagCircle49h12_create()
-            self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
-                                                        self.tag_families['tagCircle49h12'], hamming)
-        elif 'tagCustom48h12' in self.params['families']:
-            self.tag_families['tagCustom48h12'] = self.libc.tagCustom48h12_create()
-            self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
-                                                        self.tag_families['tagCustom48h12'], hamming)
-        elif 'tagStandard41h12' in self.params['families']:
-            self.tag_families['tagStandard41h12'] = self.libc.tagStandard41h12_create()
-            self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
-                                                        self.tag_families['tagStandard41h12'], hamming)
-        elif 'tagStandard52h13' in self.params['families']:
-            self.tag_families['tagStandard52h13'] = self.libc.tagStandard52h13_create()
-            self.libc.apriltag_detector_add_family_bits(self.tag_detector_ptr,
-                                                        self.tag_families['tagStandard52h13'], hamming)
-        else:
-            raise Exception('Unrecognized tag family name. Use e.g. \'tag36h11\'.\n')
+                                                        self.tag_families[family][0], hamming)
 
         # configure the parameters of the detector
         self.tag_detector_ptr.contents.nthreads = int(self.params['nthreads'])
@@ -333,23 +316,8 @@ class Detector(object):
             self.libc.apriltag_detector_destroy(self.tag_detector_ptr)
 
             # destroy the tag families
-            for family, tf in self.tag_families.items():
-                if 'tag16h5' == family:
-                    self.libc.tag16h5_destroy(tf)
-                elif 'tag25h9' == family:
-                    self.libc.tag25h9_destroy(tf)
-                elif 'tag36h11' == family:
-                    self.libc.tag36h11_destroy(tf)
-                elif 'tagCircle21h7' == family:
-                    self.libc.tagCircle21h7_destroy(tf)
-                elif 'tagCircle49h12' == family:
-                    self.libc.tagCircle49h12_destroy(tf)
-                elif 'tagCustom48h12' == family:
-                    self.libc.tagCustom48h12_destroy(tf)
-                elif 'tagStandard41h12' == family:
-                    self.libc.tagStandard41h12_destroy(tf)
-                elif 'tagStandard52h13' == family:
-                    self.libc.tagStandard52h13_destroy(tf)
+            for tf, destroy_fn in self.tag_families.values():
+                destroy_fn(tf)
 
     def detect(self, img, estimate_tag_pose=False, camera_params=None, tag_size=None):
         """

--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -148,6 +148,8 @@ class Detection():
     """
     Combined pythonic wrapper for apriltag_detection and apriltag_pose
     """
+    __slots__ = ('tag_family', 'tag_id', 'hamming', 'decision_margin',
+                 'homography', 'center', 'corners', 'pose_R', 'pose_t', 'pose_err')
 
     def __init__(self):
         self.tag_family = None

--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -323,7 +323,7 @@ class Detector(object):
         self.tag_detector_ptr.contents.quad_decimate = float(self.params['quad_decimate'])
         self.tag_detector_ptr.contents.quad_sigma = float(self.params['quad_sigma'])
         self.tag_detector_ptr.contents.refine_edges = int(self.params['refine_edges'])
-        self.tag_detector_ptr.contents.decode_sharpening = int(self.params['decode_sharpening'])
+        self.tag_detector_ptr.contents.decode_sharpening = float(self.params['decode_sharpening'])
         self.tag_detector_ptr.contents.debug = int(self.params['debug'])
 
     def __del__(self):

--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -330,6 +330,15 @@ class Detector(object):
         img = numpy.ascontiguousarray(img)
         c_img = _ImageU8(height=img.shape[0], width=img.shape[1], stride=img.strides[0], buf=img.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8)))
 
+        if estimate_tag_pose:
+            if camera_params is None:
+                raise Exception(
+                    'camera_params must be provided to detect if estimate_tag_pose is set to True')
+            if tag_size is None:
+                raise Exception(
+                    'tag_size must be provided to detect if estimate_tag_pose is set to True')
+            camera_fx, camera_fy, camera_cx, camera_cy = camera_params
+
         return_info = []
 
         # detect apriltags in the image
@@ -359,15 +368,6 @@ class Detector(object):
             detection.corners = corners
 
             if estimate_tag_pose:
-                if camera_params == None:
-                    raise Exception(
-                        'camera_params must be provided to detect if estimate_tag_pose is set to True')
-                if tag_size == None:
-                    raise Exception(
-                        'tag_size must be provided to detect if estimate_tag_pose is set to True')
-
-                camera_fx, camera_fy, camera_cx, camera_cy = [c for c in camera_params]
-
                 info = _ApriltagDetectionInfo(det=apriltag,
                                               tagsize=tag_size,
                                               fx=camera_fx,


### PR DESCRIPTION
## Summary
- **Fix decode_sharpening truncation**: was cast to `int`, silently truncating the default `0.25` to `0` and disabling sharpening
- **Fix elif chain for tag families**: only the first matching family was added to the detector; now all requested families work
- **Ensure image contiguity**: non-contiguous numpy views caused silent corruption when passed to the C library
- **Hoist pose validation out of loop**: parameter checks and unpacking now run once instead of per-detection
- **Add `__slots__` to Detection**: reduces per-object memory and speeds up attribute access

## Test plan
- [ ] Verify detection still works with single family (e.g. `tag36h11`)
- [ ] Verify detection with multiple families (e.g. `tag36h11 tag25h9`)
- [ ] Verify `estimate_tag_pose=True` path still works
- [ ] Verify passing a non-contiguous image slice doesn't crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)