### PR TITLE
Ensure input image is C-contiguous

### DIFF
--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -359,6 +359,7 @@ class Detector(object):
         assert len(img.shape) == 2
         assert img.dtype == numpy.uint8
 
+        img = numpy.ascontiguousarray(img)
         c_img = _ImageU8(height=img.shape[0], width=img.shape[1], stride=img.strides[0], buf=img.ctypes.data_as(ctypes.POINTER(ctypes.c_uint8)))
 
         return_info = []


### PR DESCRIPTION
## Summary
- Non-contiguous numpy views (e.g. from slicing) cause `ctypes.data_as()` to pass incorrect memory to the C library, leading to silent corruption or crashes
- `numpy.ascontiguousarray` is a no-op for already-contiguous arrays

🤖 Generated with [Claude Code](https://claude.com/claude-code)