### PR TITLE
Add __slots__ to Detection class

### DIFF
--- a/dt_apriltags/apriltags.py
+++ b/dt_apriltags/apriltags.py
@@ -148,6 +148,8 @@ class Detection():
     """
     Combined pythonic wrapper for apriltag_detection and apriltag_pose
     """
+    __slots__ = ('tag_family', 'tag_id', 'hamming', 'decision_margin',
+                 'homography', 'center', 'corners', 'pose_R', 'pose_t', 'pose_err')
 
     def __init__(self):
         self.tag_family = None


### PR DESCRIPTION
## Summary
- Avoids allocating a `__dict__` per `Detection` instance
- Reduces memory usage and speeds up attribute access when many tags are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)