### PR TITLE
Upgrade apriltag submodule to BuildMonumental fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "apriltags"]
 	path = apriltags
-	url = https://github.com/AprilRobotics/apriltag.git
+	url = https://github.com/BuildMonumental/apriltag.git
 	branch = master


### PR DESCRIPTION
## Summary
- Points the `apriltags` submodule at `BuildMonumental/apriltag` instead of `AprilRobotics/apriltag`
- Updates to latest master (`05e90a6` — "Pass on min_cluster_pixels for early gradient cluster rejection")

🤖 Generated with [Claude Code](https://claude.com/claude-code)